### PR TITLE
Design tweaks: Consistent colors, typography, and fixing overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Corey's Todo</title>
     <script type="text/javascript" src="elm.js"></script>
-    <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,300,700' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,400,600,300,700' rel='stylesheet' type='text/css'>
     <style media="screen">
       * {
         box-sizing: border-box;

--- a/src/AppStyles.elm
+++ b/src/AppStyles.elm
@@ -24,7 +24,7 @@ taskRow =
         , ( "border-bottom", "1px solid #eee" )
         , ( "display", "flex" )
         , ( "justify-content", "space-between" )
-        , ( "font-size", "24px" )
+        , ( "font-size", "16px" )
         , ( "position", "relative" )
         , ( "color", "#3a3a3a" )
         , ( "width", "100%" )
@@ -76,11 +76,10 @@ label active =
         [ ( "color", "#9c9c9c" )
         , ( "font-size", "16px" )
         , ( "padding", "16px" )
-        , ( "letter-spacing", "0.5pt" )
         , if active then
-            ( "font-weight", "700" )
+            ( "color", "#5299FD" )
           else
-            ( "font-weight", "400" )
+            ( "color", "#9c9c9c" )
         ]
 
 
@@ -124,6 +123,7 @@ bannerControls =
         , ( "text-align", "center" )
         , ( "font-size", "36px" )
         , ( "padding", "24px 0" )
+        , ("background-color", "#5299FD")
         ]
 
 

--- a/src/Timer/View.elm
+++ b/src/Timer/View.elm
@@ -17,7 +17,7 @@ timerView model =
         second = model.seconds % 60
 
         time =
-            minute ++ ": " ++ (if second < 10 then ("0" ++ toString second) else (toString second))
+            minute ++ ":" ++ (if second < 10 then ("0" ++ toString second) else (toString second))
     in
         text time
 

--- a/src/Todo/View.elm
+++ b/src/Todo/View.elm
@@ -64,8 +64,8 @@ banner address model =
     in
         div
             [ AppStyles.banner (featureTask.id >= 0 && timer.isRunning) ]
-            [ div [ style [ ( "text-align", "center" ), ( "font-size", "18px" ), ( "padding", "24px 0" ) ] ] [ text featureTask.description ]
-            , div [ style [ ( "text-align", "center" ), ( "font-size", "56px" ), ( "font-weight", "300" ) ] ] [ Timer.View.timerView timer ]
+            [ div [ style [ ( "text-align", "center" ), ( "font-size", "18px" ), ( "font-weight", "bold" ), ( "padding", "24px 0" ), ("background-color", "#5299FD") ] ] [ text featureTask.description ]
+            , div [ style [ ( "text-align", "center" ), ( "font-size", "56px" ), ( "font-weight", "200" ), ("background-color", "#5299FD") ] ] [ Timer.View.timerView timer ]
             , div
                 [ AppStyles.bannerControls ]
                 [ span (Timer.View.timerControls (Signal.forwardTo address (HandleTime featureTask.id)) featureTask.timer) [] ]
@@ -117,7 +117,7 @@ sideNav address model =
         completedCount = List.length (List.filter (\task -> task.completed == True) model.tasks) |> toString
     in
         div
-            [ style [ ( "min-width", "35%" ), ( "white-space", "nowrap" ) ] ]
+            [ style [ ( "min-width", "35%" ), ( "white-space", "nowrap" ), ( "border-right", "1px solid #eee" ) ] ]
             [ div [ AppStyles.label (not model.showCompleted), Html.Events.onClick address ApplyTaskFilter, class "icon-list" ] [ text ("Active" ++ " (" ++ activeCount ++ ")") ]
             , div [ AppStyles.label model.showCompleted, Html.Events.onClick address ApplyTaskFilter, class "icon-list" ] [ text ("Completed" ++ " (" ++ completedCount ++ ")") ]
             ]
@@ -126,7 +126,7 @@ sideNav address model =
 view : Address Action -> Model -> Html
 view address model =
     div
-        [ style [ ( "display", "flex" ) ] ]
+        [ style [ ( "display", "flex" ), ("min-height", "100vh") ] ]
         [ Html.Lazy.lazy2 sideNav address model
         , Html.Lazy.lazy2 mainContent address model
         ]


### PR DESCRIPTION
# What

This PR introduces a few visual styling tweaks:
- Sets minimum height of the app to `100vh` so the light border on the left I've added extends the height of the window
- The default background color for the banner is now blue
- No more overflowing text in the timer labels!
- Deletes an extra space in the time format `0:00` instead of `0: 00` (it was bugging me sooo much 😱)
# Screenshots

**Before:**
<img width="670" alt="screenshot 2016-05-09 20 19 02" src="https://cloud.githubusercontent.com/assets/3958678/15132027/55afac8c-1623-11e6-8ad6-43885aefa4a8.png">

**After:**
<img width="674" alt="screenshot 2016-05-09 20 14 49" src="https://cloud.githubusercontent.com/assets/3958678/15132032/5cd92ec0-1623-11e6-821d-5bf85443eb1f.png">
## Halp

For the life of me I couldn't figure out how to set the `font-family` for the sidebar. I tried everything! And yet, the incorrect font refuses to leave. 😭 
# Gif

![](https://media.giphy.com/media/cBeuQhEmrNLP2/giphy.gif)

😇 😗 
